### PR TITLE
add h5py as a dependency and move non-host deps to run deps

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "proteus" %}
 {% set version = "1.8.0" %}
-{% set build = 0 %}
+{% set build = 1 %}
 {% set sha256 = "097cc8df364c7ec09f0e8ea3728f2fb2fce5df6a2789d3f17dfcaf1249e381da" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ requirements:
     - petsc
     - python 3
     - scorec
+    - triangle
     - superlu
     - superlu_dist
     - pychrono
@@ -61,7 +62,6 @@ requirements:
     - pytest-xdist
     - scipy
     - tetgen
-    - triangle
     - ncurses
     - pychrono
     - python 3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
   host:
     - setuptools
     - cython
+    - pybind11
     - pip
     - daetk
     - metis
@@ -42,7 +43,6 @@ requirements:
     - scorec
     - superlu
     - superlu_dist
-    - triangle
     - pychrono
     - mpi4py
     - xtensor-python
@@ -57,11 +57,11 @@ requirements:
     - matplotlib-base
     - mpi4py
     - nose
-    - pytables
     - pytest
     - pytest-xdist
     - scipy
     - tetgen
+    - triangle
     - ncurses
     - pychrono
     - python 3
@@ -78,7 +78,8 @@ requirements:
     # pinning from conda_build_config and build pinning from {{ mpi_prefix }}
     - hdf5
     - hdf5 * {{ mpi_prefix }}_*
-
+    - h5py
+    - h5py * {{ mpi_prefix }}_*
 test:
   imports:
     - proteus.clapack


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Fixes unreported issue of missing h5py.
