### PR TITLE
remove host pins for packages pinned by conda_build_config

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,8 +8,36 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_mpimpichpython3.10.____cpython:
+        CONFIG: linux_64_mpimpichpython3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_mpimpichpython3.11.____cpython:
+        CONFIG: linux_64_mpimpichpython3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_mpimpichpython3.12.____cpython:
+        CONFIG: linux_64_mpimpichpython3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_mpimpichpython3.9.____cpython:
+        CONFIG: linux_64_mpimpichpython3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_mpiopenmpipython3.10.____cpython:
+        CONFIG: linux_64_mpiopenmpipython3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_mpiopenmpipython3.11.____cpython:
+        CONFIG: linux_64_mpiopenmpipython3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_mpiopenmpipython3.12.____cpython:
+        CONFIG: linux_64_mpiopenmpipython3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_mpiopenmpipython3.9.____cpython:
+        CONFIG: linux_64_mpiopenmpipython3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,8 +8,29 @@ jobs:
     vmImage: macOS-12
   strategy:
     matrix:
-      osx_64_:
-        CONFIG: osx_64_
+      osx_64_mpimpichpython3.10.____cpython:
+        CONFIG: osx_64_mpimpichpython3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_mpimpichpython3.11.____cpython:
+        CONFIG: osx_64_mpimpichpython3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_mpimpichpython3.12.____cpython:
+        CONFIG: osx_64_mpimpichpython3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_mpimpichpython3.9.____cpython:
+        CONFIG: osx_64_mpimpichpython3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_mpiopenmpipython3.10.____cpython:
+        CONFIG: osx_64_mpiopenmpipython3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_mpiopenmpipython3.11.____cpython:
+        CONFIG: osx_64_mpiopenmpipython3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_mpiopenmpipython3.12.____cpython:
+        CONFIG: osx_64_mpiopenmpipython3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_mpiopenmpipython3.9.____cpython:
+        CONFIG: osx_64_mpiopenmpipython3.9.____cpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}

--- a/.ci_support/linux_64_mpimpichpython3.10.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.10.____cpython.yaml
@@ -1,0 +1,60 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+hdf5:
+- 1.14.3
+metis:
+- 5.1.0
+mpi:
+- mpich
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '4'
+petsc:
+- '3.21'
+petsc4py:
+- '3.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pychrono:
+- '9'
+python:
+- 3.10.* *_cpython
+scorec:
+- 2.2.8
+superlu_dist:
+- '9'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_64_mpimpichpython3.11.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.11.____cpython.yaml
@@ -1,0 +1,60 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+hdf5:
+- 1.14.3
+metis:
+- 5.1.0
+mpi:
+- mpich
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '4'
+petsc:
+- '3.21'
+petsc4py:
+- '3.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pychrono:
+- '9'
+python:
+- 3.11.* *_cpython
+scorec:
+- 2.2.8
+superlu_dist:
+- '9'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_64_mpimpichpython3.12.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.12.____cpython.yaml
@@ -1,0 +1,60 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+hdf5:
+- 1.14.3
+metis:
+- 5.1.0
+mpi:
+- mpich
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '4'
+petsc:
+- '3.21'
+petsc4py:
+- '3.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pychrono:
+- '9'
+python:
+- 3.12.* *_cpython
+scorec:
+- 2.2.8
+superlu_dist:
+- '9'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_64_mpimpichpython3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.9.____cpython.yaml
@@ -1,0 +1,60 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+hdf5:
+- 1.14.3
+metis:
+- 5.1.0
+mpi:
+- mpich
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '4'
+petsc:
+- '3.21'
+petsc4py:
+- '3.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pychrono:
+- '9'
+python:
+- 3.9.* *_cpython
+scorec:
+- 2.2.8
+superlu_dist:
+- '9'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_64_mpiopenmpipython3.10.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.10.____cpython.yaml
@@ -1,0 +1,60 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+hdf5:
+- 1.14.3
+metis:
+- 5.1.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '4'
+petsc:
+- '3.21'
+petsc4py:
+- '3.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pychrono:
+- '9'
+python:
+- 3.10.* *_cpython
+scorec:
+- 2.2.8
+superlu_dist:
+- '9'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_64_mpiopenmpipython3.11.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.11.____cpython.yaml
@@ -1,0 +1,60 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+hdf5:
+- 1.14.3
+metis:
+- 5.1.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '4'
+petsc:
+- '3.21'
+petsc4py:
+- '3.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pychrono:
+- '9'
+python:
+- 3.11.* *_cpython
+scorec:
+- 2.2.8
+superlu_dist:
+- '9'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_64_mpiopenmpipython3.12.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.12.____cpython.yaml
@@ -1,0 +1,60 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+hdf5:
+- 1.14.3
+metis:
+- 5.1.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '4'
+petsc:
+- '3.21'
+petsc4py:
+- '3.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pychrono:
+- '9'
+python:
+- 3.12.* *_cpython
+scorec:
+- 2.2.8
+superlu_dist:
+- '9'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_64_mpiopenmpipython3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.9.____cpython.yaml
@@ -1,0 +1,60 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+hdf5:
+- 1.14.3
+metis:
+- 5.1.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '4'
+petsc:
+- '3.21'
+petsc4py:
+- '3.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pychrono:
+- '9'
+python:
+- 3.9.* *_cpython
+scorec:
+- 2.2.8
+superlu_dist:
+- '9'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/osx_64_mpimpichpython3.10.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.10.____cpython.yaml
@@ -1,0 +1,60 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_compiler:
+- clang
+c_compiler_version:
+- '17'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '17'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+hdf5:
+- 1.14.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
+metis:
+- 5.1.0
+mpi:
+- mpich
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '4'
+petsc:
+- '3.21'
+petsc4py:
+- '3.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pychrono:
+- '9'
+python:
+- 3.10.* *_cpython
+scorec:
+- 2.2.8
+superlu_dist:
+- '9'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_64_mpimpichpython3.11.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.11.____cpython.yaml
@@ -1,0 +1,60 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_compiler:
+- clang
+c_compiler_version:
+- '17'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '17'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+hdf5:
+- 1.14.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
+metis:
+- 5.1.0
+mpi:
+- mpich
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '4'
+petsc:
+- '3.21'
+petsc4py:
+- '3.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pychrono:
+- '9'
+python:
+- 3.11.* *_cpython
+scorec:
+- 2.2.8
+superlu_dist:
+- '9'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_64_mpimpichpython3.12.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.12.____cpython.yaml
@@ -26,6 +26,8 @@ hdf5:
 - 1.14.3
 macos_machine:
 - x86_64-apple-darwin13.4.0
+metis:
+- 5.1.0
 mpi:
 - mpich
 mpich:
@@ -34,6 +36,20 @@ openblas:
 - 0.3.*
 openmpi:
 - '4'
+petsc:
+- '3.21'
+petsc4py:
+- '3.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pychrono:
+- '9'
+python:
+- 3.12.* *_cpython
+scorec:
+- 2.2.8
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/osx_64_mpimpichpython3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.9.____cpython.yaml
@@ -1,29 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '13'
+- '17'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- cos7
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '13'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '17'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
+metis:
+- 5.1.0
 mpi:
 - mpich
 mpich:
@@ -32,13 +36,25 @@ openblas:
 - 0.3.*
 openmpi:
 - '4'
+petsc:
+- '3.21'
+petsc4py:
+- '3.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pychrono:
+- '9'
+python:
+- 3.9.* *_cpython
+scorec:
+- 2.2.8
 superlu_dist:
 - '9'
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-- - c_stdlib_version
-  - cdt_name

--- a/.ci_support/osx_64_mpiopenmpipython3.10.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.10.____cpython.yaml
@@ -1,0 +1,60 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_compiler:
+- clang
+c_compiler_version:
+- '17'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '17'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+hdf5:
+- 1.14.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
+metis:
+- 5.1.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '4'
+petsc:
+- '3.21'
+petsc4py:
+- '3.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pychrono:
+- '9'
+python:
+- 3.10.* *_cpython
+scorec:
+- 2.2.8
+superlu_dist:
+- '9'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_64_mpiopenmpipython3.11.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.11.____cpython.yaml
@@ -1,0 +1,60 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_compiler:
+- clang
+c_compiler_version:
+- '17'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '17'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+hdf5:
+- 1.14.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
+metis:
+- 5.1.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '4'
+petsc:
+- '3.21'
+petsc4py:
+- '3.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pychrono:
+- '9'
+python:
+- 3.11.* *_cpython
+scorec:
+- 2.2.8
+superlu_dist:
+- '9'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_64_mpiopenmpipython3.12.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.12.____cpython.yaml
@@ -1,0 +1,60 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_compiler:
+- clang
+c_compiler_version:
+- '17'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '17'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+hdf5:
+- 1.14.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
+metis:
+- 5.1.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '4'
+petsc:
+- '3.21'
+petsc4py:
+- '3.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pychrono:
+- '9'
+python:
+- 3.12.* *_cpython
+scorec:
+- 2.2.8
+superlu_dist:
+- '9'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_64_mpiopenmpipython3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.9.____cpython.yaml
@@ -1,0 +1,60 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_compiler:
+- clang
+c_compiler_version:
+- '17'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '17'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+hdf5:
+- 1.14.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
+metis:
+- 5.1.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '4'
+petsc:
+- '3.21'
+petsc4py:
+- '3.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pychrono:
+- '9'
+python:
+- 3.9.* *_cpython
+scorec:
+- 2.2.8
+superlu_dist:
+- '9'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version

--- a/README.md
+++ b/README.md
@@ -29,17 +29,115 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
+              <td>linux_64_mpimpichpython3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8293&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpimpichpython3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64</td>
+              <td>linux_64_mpimpichpython3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8293&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpimpichpython3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_mpimpichpython3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8293&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpimpichpython3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_mpimpichpython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8293&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpimpichpython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_mpiopenmpipython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8293&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpiopenmpipython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_mpiopenmpipython3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8293&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpiopenmpipython3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_mpiopenmpipython3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8293&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpiopenmpipython3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_mpiopenmpipython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8293&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpiopenmpipython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpimpichpython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8293&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpimpichpython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpimpichpython3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8293&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpimpichpython3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpimpichpython3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8293&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpimpichpython3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpimpichpython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8293&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpimpichpython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpiopenmpipython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8293&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpiopenmpipython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpiopenmpipython3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8293&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpiopenmpipython3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpiopenmpipython3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8293&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpiopenmpipython3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpiopenmpipython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8293&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proteus-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpiopenmpipython3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,5 @@
 mpi:
   - mpich
-  - openmpi
 pychrono:
   - 9
 scorec:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,7 @@
 mpi:
   - mpich
+  - openmpi
 pychrono:
   - 9
+scorec:
+  - 2.2.8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,6 @@ requirements:
     - petsc
     - python
     - scorec
-    - triangle
     - superlu
     - superlu_dist
     - pychrono
@@ -65,7 +64,6 @@ requirements:
     - scorec
     - python 3
     - future
-    - triangle
     - {{ pin_compatible('openblas', max_pin='x.x') }}
     - {{ pin_compatible('petsc4py', max_pin='x.x') }}
     - {{ pin_compatible('cython', max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ requirements:
     - petsc
     - python
     - scorec
+    - triangle
     - superlu
     - superlu_dist
     - pychrono
@@ -59,6 +60,7 @@ requirements:
     - mpi4py
     - scipy
     - tetgen
+    - triangle
     - ncurses
     - pychrono
     - scorec

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "proteus" %}
 {% set version = "1.8.3" %}
-{% set build = 1 %}
+{% set build = 2 %}
 {% set sha256 = "315f0600044e2ad86592c248a9a4ca87dc58c1d678af2c27a9ddde802b555618" %}
 
 package:
@@ -32,24 +32,24 @@ requirements:
     - cython >=3
     - pybind11
     - pip
-    - metis >=5.1.0
+    - metis
     - {{ mpi }}
     - numpy >=1.25.1
     - openblas
     - parmetis >=4.0.3
-    - petsc4py >=3.21
-    - petsc >=3.21
-    - python 3
-    - scorec >=2.2.8
+    - petsc4py
+    - petsc
+    - python
+    - scorec
     - triangle
     - superlu
     - superlu_dist
-    - pychrono >=9
+    - pychrono
     - mpi4py
     - xtensor-python
     - eigen
     # pinning from conda_build_config and build pinning from {{ mpi_prefix }}
-    - hdf5 >=1.14.1
+    - hdf5
     - hdf5 * {{ mpi_prefix }}_*
   run:
     #for testing
@@ -61,8 +61,8 @@ requirements:
     - scipy
     - tetgen
     - ncurses
-    - pychrono >=9
-    - scorec >=2.2.8
+    - pychrono
+    - scorec
     - python 3
     - future
     - triangle


### PR DESCRIPTION
causes problems for bot solving environment

(in particular, metis 5.1.1, when 5.1.0 is use most places because 5.1.1 is broken)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
